### PR TITLE
Status 200 OK zou mogelijk moeten zijn voor POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ DELETE | verwijderen van een resource                                           
 
 Code                         | GET | HEAD | PUT | POST                | PATCH | DELETE | Error object 
 ----                         | --- | ---  | --- | ----                | ----- | ------ | ------------ 
-200 : OK (sync)              | X   | X    | X   |                     | X     | X      |              
+200 : OK (sync)              | X   | X    | X   | X                   | X     | X      |              
 201 : Created (sync)         |     |      |     | X                   |       |        |              
 202 : Accepted (async)       |     |      | X   | X                   | X     | X      |              
 204 : No content             |     |      | X   | X                   | X     | X      |              


### PR DESCRIPTION
Soms worden POST requests gebruik als vervanging van een GET met body. Bijvoorbeeld bij een uitgebreide search request komt de search query (die van groot formaat kan zijn) mee als body. Bij dit soort POST request wordt er dus geen resource aangemaakt, en zou er een status 200 OK terug moeten komen.